### PR TITLE
Proposal to standardize on three letter prefixes (ANF/HSS, others to follow as needed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ UIButton *settingsButton;
 UIButton *setBut;
 ```
 
-A common, per project prefix should always be used for class names and constants. It may however be omitted for Core Data entity names. There is a number of existing classes using two letter prefixes ('AF' for cross client logic, 'BN' for classes inherited from Betternet etc.) but going forward all new classes should be using three letter prefixes to avoid clashes with system components. Prefixes in use as follows:
+A common, per project prefix should always be used for class names and constants. It may however be omitted for Core Data entity names. There are a number of existing classes using two letter prefixes ('AF' for cross client logic, 'BN' for classes inherited from Betternet etc.) but going forward all new classes should be using three letter prefixes to avoid clashes with system components. Prefixes in use as follows:
 
 Cross-client components: ANF
 Hotspot Shield: HSS

--- a/README.md
+++ b/README.md
@@ -206,7 +206,12 @@ UIButton *settingsButton;
 UIButton *setBut;
 ```
 
-A common, per project prefix should always be used for class names and constants. It may however be omitted for Core Data entity names. For common AnchorFree entities prefix 'AF' should be used. Each project should use its own prefix for custom entities (BN, HT etc.). New projects should use three letter prefixes as Apple reserves two letter ones for present and future APIs.
+A common, per project prefix should always be used for class names and constants. It may however be omitted for Core Data entity names. There is a number of existing classes using two letter prefixes ('AF' for cross client logic, 'BN' for classes inherited from Betternet etc.) but going forward all new classes should be using three letter prefixes to avoid clashes with system components. Prefixes in use as follows:
+
+Cross-client components: ANF
+Hotspot Shield: HSS
+
+Others TBD
 
 Constants should be camel-case with all words capitalized and prefixed by the related class name for clarity.
 


### PR DESCRIPTION
WHY:

We ought to settle on three letter prefixes for our various components.

WHAT:

- Propose 'ANF' for cross-client components (this has been discussed with the other devs in the Redwood City office, including Arthur).
- Propose 'HSS' for Hotspot Shield components (this was already effectively in place).

TESTING:

We'd better stick to whatever we agree with.

NOTES:

Not aware of other three letter prefixes in use but happy to add them, or come up with new ones for Betternet/Hexa/VPN360/etc.

However, I don't want to drag this discussion long, we can always patch this again to settle further prefixes.